### PR TITLE
allow "use strict"; in function body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,9 @@ export class ComputedObservationAdapter {
         };
       } else {
         try {
-          let body = getFunctionBody(src).trim().substr('return'.length).trim();
+          let body = getFunctionBody(src).trim();
+          body = body.replace(/^['"]use strict['"];/, '').trim();
+          body = body.substr('return'.length).trim();
           body = body.replace(/;$/, '');
           expression = this.parser.parse(body);
         } catch (ex) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -31,6 +31,15 @@ class Foo {
   get xup() {
     return this._bar + ' some literal';
   }
+
+  get strict1() {
+    "use strict";
+    return this._bar + ' some literal';
+  }
+  get strict2() {
+    'use strict';
+    return this._bar + ' some literal';
+  }
 }
 
 describe('plugin', () => {
@@ -96,6 +105,8 @@ describe('adapter', () => {
     expect(adapter.getObserver(foo, 'bar', Object.getPropertyDescriptor(foo, 'bar'))).not.toBe(null);
     expect(adapter.getObserver(foo, 'baz', Object.getPropertyDescriptor(foo, 'baz'))).toBe(null);
     expect(adapter.getObserver(foo, 'xup', Object.getPropertyDescriptor(foo, 'xup'))).not.toBe(null);
+    expect(adapter.getObserver(foo, 'strict1', Object.getPropertyDescriptor(foo, 'strict1'))).not.toBe(null);
+    expect(adapter.getObserver(foo, 'strict2', Object.getPropertyDescriptor(foo, 'strict2'))).not.toBe(null);
   });
 
   it('returns observer matching property-observer interface', () => {


### PR DESCRIPTION
TypeScript emits "use strict" since version 1.8 by default, which prevents usage of aurelia-computed ("Unable to parse" error is logged). This PR fixes the issue. Thanks for you really useful plugin!
